### PR TITLE
Separate in container scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ addons:
     sources:
     - debian-sid
 script:
-  - shellcheck script/*
+  - for file in $(find script -type f); do shellcheck --format=tty --shell=bash $file; done;
 sudo: false

--- a/README.md
+++ b/README.md
@@ -123,6 +123,11 @@ This script is typically only called from your CD server.
 [`script/cleanup`][cleanup] is used to cleanup any cruft that builds up during development.
 This can range from log files to dangling Docker containers and images.
 
+### script/docker
+
+The scripts in [`script/docker`][script/docker] are designed to be run by the top-level scripts inside a docker container.
+This is mainly to achieve speed up so don't have to fire up a new container for each command.
+
 [bootstrap]: script/bootstrap
 [setup]: script/setup
 [update]: script/update

--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ to always ensure that the application is up to date.
 **TODO**: If called from
 [`script/cibuild`][cibuild], it should probably reset the application to a clean state.
 
-
 ### script/cibuild
 
 [`script/cibuild`][cibuild] is used for your continuous integration server.
@@ -114,9 +113,8 @@ the requested environment.
 
 ### script/cddeploy
 
-[`script/cibuild`][cddeploy] is used for your continuous deployment pipeline.
+[`script/cddeploy`][cddeploy] is used for your continuous deployment pipeline.
 This script is typically only called from your CD server.
-
 
 ### script/cleanup
 

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -12,8 +12,5 @@ if [[ ! -f ".env" ]]; then
   exit 1
 fi
 
-echo "==> Updating gems…"
-bundle check || bundle install --quiet
-
 echo "==> Build docker images…"
 docker-compose build > /dev/null

--- a/script/cleanup
+++ b/script/cleanup
@@ -6,7 +6,7 @@ set -eu
 
 cd "$(dirname "$0")/.."
 
-docker-compose run --rm web bin/rails log:clear tmp:clear &> /dev/null
+docker-compose run --rm web script/docker/cleanup
 
 docker-compose stop &> /dev/null || true &> /dev/null
 docker-compose rm --force &> /dev/null || true &> /dev/null

--- a/script/docker/cleanup
+++ b/script/docker/cleanup
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# script/update: Update application to run for its current checkout.
+
+set -e
+
+cd "$(dirname "$0")/../.."
+
+bin/rails log:clear tmp:clear &> /dev/null

--- a/script/docker/setup
+++ b/script/docker/setup
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# script/setup: Set up application for the first time after cloning, or set it
+#               back to the initial first unused state.
+
+set -e
+
+cd "$(dirname "$0")/../.."
+
+
+echo "==> Setting up DB…"
+bin/rails db:setup
+
+if [ -z "$RAILS_ENV" ] && [ -z "$RACK_ENV" ]; then
+  # Only things for a development environment will run inside here
+  # Do things that need to be done to the application to set up for the first
+  # time. Or things needed to be run to to reset the application back to first
+  # use experience. These things are scoped to the application's domain.
+  true
+fi
+
+echo "==> App is now ready to go!"

--- a/script/docker/test
+++ b/script/docker/test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # script/test: Run test suite for application. Optionally pass in a path to an
 #              individual test file to run a single test.
@@ -6,19 +6,15 @@
 
 set -e
 
-cd "$(dirname "$0")/.."
+cd "$(dirname "$0")/../.."
 
-[ -z "$DEBUG" ] || set -x
-
-export RAILS_ENV="test"
-
-script/update
+script/docker/update
 
 echo "==> Running tests…"
 
 if [ -n "$1" ]; then
   # pass arguments to test call. This is useful for calling a single test.
-  docker-compose run --rm web script/docker/test "$1"
+  bin/rake test "$1"
 else
-  docker-compose run --rm web script/docker/test spec
+  bin/rake test
 fi

--- a/script/docker/update
+++ b/script/docker/update
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# script/update: Update application to run for its current checkout.
+
+set -e
+
+cd "$(dirname "$0")/../.."
+
+echo "==> Updating db…"
+# run all database migrations to ensure everything is up to date.
+bin/rails db:migrate

--- a/script/setup
+++ b/script/setup
@@ -9,15 +9,4 @@ cd "$(dirname "$0")/.."
 
 script/bootstrap
 
-echo "==> Setting up DB…"
-docker-compose run --rm web rails db:setup
-
-if [ -z "$RAILS_ENV" ] && [ -z "$RACK_ENV" ]; then
-  # Only things for a development environment will run inside here
-  # Do things that need to be done to the application to set up for the first
-  # time. Or things needed to be run to to reset the application back to first
-  # use experience. These things are scoped to the application's domain.
-  true
-fi
-
-echo "==> App is now ready to go!"
+docker-compose run --rm web script/docker/setup

--- a/script/update
+++ b/script/update
@@ -9,5 +9,5 @@ cd "$(dirname "$0")/.."
 script/bootstrap
 
 echo "==> Updating db…"
-# run all database migrations to ensure everything is up to date.
-docker-compose run --rm web bin/rails db:migrate
+# run update script inside a container
+docker-compose run --rm web script/docker/update


### PR DESCRIPTION
Found these scripts ran slowly in Landmrk in part due to spinning up a lot of containers. Attempting to reduce the number of containers started by having separate scripts to be run inside a container rather than individual commands executed by `docker-compose run`.

Plus a bit of tidying: README corrections and no need to install gems locally as using docker to run the app.